### PR TITLE
add prop to keep player mounted on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ export default Unity;
 ```
 
 ## Props
+- `androidKeepPlayerMounted?: boolean` - if set to true, keep the player mounted even when the view that contains it has lost focus.  The player will be paused on blur and resumed on focus.  **FOR ANDROID:** has no effect on iOS.
 - `onUnityMessage?: (event: NativeSyntheticEvent)` - receives a message from a Unity
 - `style: ViewStyle` - styles the UnityView.  (Won't show on Android without dimensions.  Recommended to give it `flex: 1` as in the example)
 

--- a/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnity.java
+++ b/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnity.java
@@ -1,6 +1,5 @@
 package com.azesmwayreactnativeunity;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.graphics.PixelFormat;
 import android.os.Build;
@@ -10,12 +9,10 @@ import android.view.WindowManager;
 import com.unity3d.player.UnityPlayer;
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 
-import java.util.concurrent.CopyOnWriteArraySet;
-
 public class ReactNativeUnity {
     private static UnityPlayer unityPlayer;
-    private static boolean _isUnityReady;
-    private static boolean _isUnityPaused;
+    public static boolean _isUnityReady;
+    public static boolean _isUnityPaused;
 
     public static UnityPlayer getPlayer() {
         if (!_isUnityReady) {
@@ -50,7 +47,7 @@ public class ReactNativeUnity {
                 unityPlayer = new UnityPlayer(activity);
 
                 try {
-                    // wait a moument. fix unity cannot start when startup.
+                    // wait a moment. fix unity cannot start when startup.
                     Thread.sleep(1000);
                 } catch (Exception e) {
                 }

--- a/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnityView.java
+++ b/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnityView.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 @SuppressLint("ViewConstructor")
 public class ReactNativeUnityView extends FrameLayout {
     private UnityPlayer view;
+    public boolean keepPlayerMounted = false;
 
     public ReactNativeUnityView(Context context) {
         super(context);
@@ -40,8 +41,20 @@ public class ReactNativeUnityView extends FrameLayout {
     @Override
     public void onWindowFocusChanged(boolean hasWindowFocus) {
         super.onWindowFocusChanged(hasWindowFocus);
-        if (view != null) {
-            view.windowFocusChanged(hasWindowFocus);
+        if (view == null) {
+            return;
+        }
+        view.windowFocusChanged(hasWindowFocus);
+
+        if (!keepPlayerMounted) {
+            return;
+        }
+
+        // pause Unity on blur, resume on focus
+        if (hasWindowFocus && ReactNativeUnity._isUnityPaused) {
+            view.resume();
+        } else if (!hasWindowFocus && !ReactNativeUnity._isUnityPaused) {
+            view.pause();
         }
     }
 
@@ -55,7 +68,9 @@ public class ReactNativeUnityView extends FrameLayout {
 
     @Override
     protected void onDetachedFromWindow() {
-        ReactNativeUnity.addUnityViewToBackground();
+        if (!this.keepPlayerMounted) {
+            ReactNativeUnity.addUnityViewToBackground();
+        }
         super.onDetachedFromWindow();
     }
 }

--- a/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnityViewManager.java
+++ b/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnityViewManager.java
@@ -1,7 +1,6 @@
 package com.azesmwayreactnativeunity;
 
 import android.os.Handler;
-import android.util.Log;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -17,7 +16,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.unity3d.player.UnityPlayer;
 
@@ -161,5 +160,10 @@ public class ReactNativeUnityViewManager extends SimpleViewManager<ReactNativeUn
     @Override
     public void onViewDetachedFromWindow(View v) {
 
+    }
+
+    @ReactProp(name = "androidKeepPlayerMounted", defaultBoolean = false)
+    public void setAndroidKeepPlayerMounted(ReactNativeUnityView view, boolean keepPlayerMounted) {
+        view.keepPlayerMounted = keepPlayerMounted;
     }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,7 +25,7 @@ const ReactNativeUnityView =
 export default class UnityView extends React.Component<ReactNativeUnityViewProps> {
   static defaultProps = {};
 
-  constructor(props: any) {
+  constructor(props: ReactNativeUnityViewProps) {
     super(props);
   }
 


### PR DESCRIPTION
ANDROID ONLY: This adds a prop which allows the user to specify that the Unity player should not be unmounted when the view that contains it loses focus.

As the original intention was to save battery by unmounting the view, I added code to pause the Unity player when the view is unfocused and resume it when it regains focus.  Some basic CPU profiling showed that the Unity player CPU usage is reduced by about 2/3 when paused. 