### PR TITLE
feat: implement .resumeUnity() & .pauseUnity() on android

### DIFF
--- a/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnityViewManager.java
+++ b/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnityViewManager.java
@@ -81,6 +81,11 @@ public class ReactNativeUnityViewManager extends SimpleViewManager<ReactNativeUn
             case "unloadUnity":
                 unloadUnity(view);
                 return;
+            case "pauseUnity":
+                ReactNativeUnity.getPlayer().pause();
+                return;
+            case "resumeUnity":
+                ReactNativeUnity.getPlayer().resume();
             default:
                 throw new IllegalArgumentException(String.format(
                         "Unsupported command %s received by %s.",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,6 +55,14 @@ export default class UnityView extends React.Component<ReactNativeUnityViewProps
     );
   }
 
+  public resumeUnity() {
+    UIManager.dispatchViewManagerCommand(
+      findNodeHandle(this),
+      this.getCommand('resumeUnity'),
+      []
+    );
+  }
+
   private getCommand(cmd: string): any {
     if (Platform.OS === 'ios') {
       return UIManager.getViewManagerConfig('ReactNativeUnityView').Commands[


### PR DESCRIPTION
.pauseUnity() was not implemented on Android
I added .resumeUnity() as well