### PR TITLE
Bubble up Unity Player lifecycle events

### DIFF
--- a/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnity.java
+++ b/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnity.java
@@ -7,6 +7,7 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 
 import com.unity3d.player.UnityPlayer;
+import com.unity3d.player.IUnityPlayerLifecycleEvents;
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 
 public class ReactNativeUnity {
@@ -30,7 +31,7 @@ public class ReactNativeUnity {
         return _isUnityPaused;
     }
 
-    public static void createPlayer(final Activity activity, final CreateCallback callback) {
+    public static void createPlayer(final Activity activity, final UnityPlayerCallback callback) {
         if (unityPlayer != null) {
             callback.onReady();
             return;
@@ -45,7 +46,17 @@ public class ReactNativeUnity {
                     fullScreen = true;
                 }
 
-                unityPlayer = new UnityPlayer(activity);
+                unityPlayer = new UnityPlayer(activity, new IUnityPlayerLifecycleEvents() {
+                  @Override
+                  public void onUnityPlayerUnloaded() {
+                    callback.onUnload();
+                  }
+
+                  @Override
+                  public void onUnityPlayerQuitted() {
+                    callback.onQuit();
+                  }
+                });
 
                 try {
                     // wait a moment. fix unity cannot start when startup.
@@ -120,7 +131,9 @@ public class ReactNativeUnity {
         unityPlayer.resume();
     }
 
-    public interface CreateCallback {
+    public interface UnityPlayerCallback {
         void onReady();
+        void onUnload();
+        void onQuit();
     }
 }

--- a/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnityViewManager.java
+++ b/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnityViewManager.java
@@ -49,10 +49,26 @@ public class ReactNativeUnityViewManager extends SimpleViewManager<ReactNativeUn
         if (ReactNativeUnity.getPlayer() != null) {
             view.setUnityPlayer(ReactNativeUnity.getPlayer());
         } else {
-            ReactNativeUnity.createPlayer(reactContext.getCurrentActivity(), new ReactNativeUnity.CreateCallback() {
+            ReactNativeUnity.createPlayer(reactContext.getCurrentActivity(), new ReactNativeUnity.UnityPlayerCallback() {
                 @Override
                 public void onReady() {
                     view.setUnityPlayer(ReactNativeUnity.getPlayer());
+                }
+
+                @Override
+                public void onUnload() {
+                  WritableMap data = Arguments.createMap();
+                  data.putString("message", "MyMessage");
+                  ReactContext reactContext = (ReactContext) view.getContext();
+                  reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(view.getId(), "onPlayerUnload", data);
+                }
+
+                @Override
+                public void onQuit() {
+                  WritableMap data = Arguments.createMap();
+                  data.putString("message", "MyMessage");
+                  ReactContext reactContext = (ReactContext) view.getContext();
+                  reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(view.getId(), "onPlayerQuit", data);
                 }
             });
         }
@@ -63,6 +79,8 @@ public class ReactNativeUnityViewManager extends SimpleViewManager<ReactNativeUn
     public Map getExportedCustomBubblingEventTypeConstants() {
         return MapBuilder.builder()
                 .put("onUnityMessage", MapBuilder.of("phasedRegistrationNames", MapBuilder.of("bubbled", "onUnityMessage")))
+                .put("onPlayerUnload", MapBuilder.of("phasedRegistrationNames", MapBuilder.of("bubbled", "onPlayerUnload")))
+                .put("onPlayerQuit", MapBuilder.of("phasedRegistrationNames", MapBuilder.of("bubbled", "onPlayerQuit")))
                 .build();
     }
 

--- a/ios/ReactNativeUnity.m
+++ b/ios/ReactNativeUnity.m
@@ -62,7 +62,7 @@ static id<RNUnityFramework> Unity_ufw;
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"onUnityMessage", @"onPlayerUnload"];
+    return @[@"onUnityMessage", @"onPlayerUnload", @"onPlayerQuit"];
 }
 
 @end

--- a/ios/ReactNativeUnity.m
+++ b/ios/ReactNativeUnity.m
@@ -1,5 +1,26 @@
 #import "ReactNativeUnity.h"
 
+UnityFramework* UnityFrameworkLoad()
+{
+    NSString* bundlePath = nil;
+    bundlePath = [[NSBundle mainBundle] bundlePath];
+    bundlePath = [bundlePath stringByAppendingString: @"/Frameworks/UnityFramework.framework"];
+
+    NSBundle* bundle = [NSBundle bundleWithPath: bundlePath];
+    if ([bundle isLoaded] == false) [bundle load];
+
+    UnityFramework* ufw = [bundle.principalClass getInstance];
+    if (![ufw appController])
+    {
+        // unity is not initialized
+        [ufw setExecuteHeader: &_mh_execute_header];
+    }
+
+    [ufw setDataBundleId: [bundle.bundleIdentifier cStringUsingEncoding:NSUTF8StringEncoding]];
+
+    return ufw;
+}
+
 int gArgc = 1;
 
 @implementation ReactNativeUnity
@@ -19,21 +40,8 @@ static id<RNUnityFramework> Unity_ufw;
 }
 
 + (id<RNUnityFramework>) launchWithOptions:(NSDictionary*)applaunchOptions {
-
-    NSString* bundlePath = nil;
-    bundlePath = [[NSBundle mainBundle] bundlePath];
-    bundlePath = [bundlePath stringByAppendingString: @"/Frameworks/UnityFramework.framework"];
-
-    NSBundle* bundle = [NSBundle bundleWithPath: bundlePath];
-    if ([bundle isLoaded] == false) [bundle load];
-
-    id<RNUnityFramework> framework = [bundle.principalClass getInstance];
-
-    if (![framework appController]) {
-        [framework setExecuteHeader: &_mh_execute_header];
-    }
-
-    [framework setDataBundleId: [bundle.bundleIdentifier cStringUsingEncoding:NSUTF8StringEncoding]];
+    id ufw = UnityFrameworkLoad();
+    [self setUfw: ufw];
 
     unsigned count = (int) [[[NSProcessInfo processInfo] arguments] count];
     char **array = (char **)malloc((count + 1) * sizeof(char*));
@@ -44,10 +52,7 @@ static id<RNUnityFramework> Unity_ufw;
     }
     array[count] = NULL;
 
-    [framework runEmbeddedWithArgc: gArgc argv: array appLaunchOpts: applaunchOptions];
-
-    [self setUfw:framework];
-    [framework registerFrameworkListener:self.ufw];
+    [[self ufw] runEmbeddedWithArgc: gArgc argv: array appLaunchOpts: applaunchOptions];
 
     return self.ufw;
 }
@@ -57,7 +62,7 @@ static id<RNUnityFramework> Unity_ufw;
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"onUnityMessage"];
+    return @[@"onUnityMessage", @"onPlayerUnload"];
 }
 
 @end

--- a/ios/ReactNativeUnityView.h
+++ b/ios/ReactNativeUnityView.h
@@ -10,6 +10,7 @@
 
 @property (nonatomic, copy) RCTBubblingEventBlock _Nullable onUnityMessage;
 @property (nonatomic, copy) RCTBubblingEventBlock _Nullable onPlayerUnload;
+@property (nonatomic, copy) RCTBubblingEventBlock _Nullable onPlayerQuit;
 
 + (void)UnityPostMessage:(NSString* _Nonnull )gameObject methodName:(NSString* _Nonnull)methodName message:(NSString* _Nonnull) message;
 + (void)unloadUnity;

--- a/ios/ReactNativeUnityView.h
+++ b/ios/ReactNativeUnityView.h
@@ -1,13 +1,15 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTView.h>
 #import <React/RCTEventDispatcher.h>
+#include <UnityFramework/UnityFramework.h>
 #include <UnityFramework/NativeCallProxy.h>
 
-@interface ReactNativeUnityView : RCTView <NativeCallsProtocol>
+@interface ReactNativeUnityView : RCTView <NativeCallsProtocol, UnityFrameworkListener>
 
 @property (nonatomic, strong) UIView* _Nullable uView;
 
 @property (nonatomic, copy) RCTBubblingEventBlock _Nullable onUnityMessage;
+@property (nonatomic, copy) RCTBubblingEventBlock _Nullable onPlayerUnload;
 
 + (void)UnityPostMessage:(NSString* _Nonnull )gameObject methodName:(NSString* _Nonnull)methodName message:(NSString* _Nonnull) message;
 + (void)unloadUnity;

--- a/ios/ReactNativeUnityView.m
+++ b/ios/ReactNativeUnityView.m
@@ -10,6 +10,7 @@ NSDictionary* appLaunchOpts;
     self = [super initWithFrame:frame];
     if (self) {
         _uView = [[[ReactNativeUnity launchWithOptions:appLaunchOpts] appController] rootView];
+        [[ReactNativeUnity ufw] registerFrameworkListener:self];
         [FrameworkLibAPI registerAPIforNativeCalls:self];
     }
     return self;
@@ -35,7 +36,6 @@ NSDictionary* appLaunchOpts;
     if(main != nil) {
         [main makeKeyAndVisible];
         if ([ReactNativeUnity ufw]) {
-            [[ReactNativeUnity ufw] unregisterFrameworkListener:[ReactNativeUnity ufw]];
             [[ReactNativeUnity ufw] unloadApplication];
         }
     }
@@ -55,6 +55,20 @@ NSDictionary* appLaunchOpts;
 
         self.onUnityMessage(data);
     }
+}
+
+- (void)unityDidUnload:(NSNotification*)notification {
+    [[ReactNativeUnity ufw] unregisterFrameworkListener:self];
+    [ReactNativeUnity setUfw: nil];
+
+    if (self.onPlayerUnload) {
+        self.onPlayerUnload(nil);
+    }
+}
+
+- (void)unityDidQuit:(NSNotification*)notification {
+    [[ReactNativeUnity ufw] unregisterFrameworkListener:self];
+    [ReactNativeUnity setUfw: nil];
 }
 
 @end

--- a/ios/ReactNativeUnityView.m
+++ b/ios/ReactNativeUnityView.m
@@ -11,7 +11,9 @@ NSDictionary* appLaunchOpts;
     if (self) {
         _uView = [[[ReactNativeUnity launchWithOptions:appLaunchOpts] appController] rootView];
         [[ReactNativeUnity ufw] registerFrameworkListener:self];
-        [FrameworkLibAPI registerAPIforNativeCalls:self];
+        // HACK: Sometimes we can't find NativeCallsProxy.h during linking stage
+        // Let's defer that to runtime to fix the build
+        [NSClassFromString(@"FrameworkLibAPI") registerAPIforNativeCalls:self];
     }
     return self;
 }

--- a/ios/ReactNativeUnityView.m
+++ b/ios/ReactNativeUnityView.m
@@ -69,6 +69,10 @@ NSDictionary* appLaunchOpts;
 - (void)unityDidQuit:(NSNotification*)notification {
     [[ReactNativeUnity ufw] unregisterFrameworkListener:self];
     [ReactNativeUnity setUfw: nil];
+
+    if (self.onPlayerQuit) {
+        self.onPlayerQuit(nil);
+    }
 }
 
 @end

--- a/ios/ReactNativeUnityViewManager.m
+++ b/ios/ReactNativeUnityViewManager.m
@@ -13,6 +13,7 @@
 RCT_EXPORT_MODULE(ReactNativeUnityView)
 RCT_EXPORT_VIEW_PROPERTY(onUnityMessage, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPlayerUnload, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPlayerQuit, RCTBubblingEventBlock)
 
 - (UIView *)view
 {
@@ -70,7 +71,7 @@ RCT_EXPORT_METHOD(unloadUnity:(nonnull NSNumber*) reactTag) {
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"onUnityMessage", @"onPlayerUnload"];
+    return @[@"onUnityMessage", @"onPlayerUnload", @"onPlayerQuit"];
 }
 
 RCT_EXPORT_METHOD(resumeUnity:(nonnull NSNumber*) reactTag) {

--- a/ios/ReactNativeUnityViewManager.m
+++ b/ios/ReactNativeUnityViewManager.m
@@ -12,6 +12,7 @@
 
 RCT_EXPORT_MODULE(ReactNativeUnityView)
 RCT_EXPORT_VIEW_PROPERTY(onUnityMessage, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPlayerUnload, RCTBubblingEventBlock)
 
 - (UIView *)view
 {
@@ -69,7 +70,7 @@ RCT_EXPORT_METHOD(unloadUnity:(nonnull NSNumber*) reactTag) {
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"onUnityMessage"];
+    return @[@"onUnityMessage", @"onPlayerUnload"];
 }
 
 RCT_EXPORT_METHOD(resumeUnity:(nonnull NSNumber*) reactTag) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,8 @@ type ReactNativeUnityViewProps = {
   androidKeepPlayerMounted?: boolean;
   fullScreen?: boolean;
   onUnityMessage?: (event: NativeSyntheticEvent<UnityMessage>) => void;
+  onPlayerUnload?: (event: NativeSyntheticEvent<void>) => void;
+  onPlayerQuit?: (event: NativeSyntheticEvent<void>) => void;
   style?: ViewStyle;
 };
 


### PR DESCRIPTION
I'm creating an application, where I conditionally load the player and allow the players to unload it once the game is finished, so I need to expose these events to properly manage the player lifecycle and my application state.

I adapted the `UnityFrameworkLoad` change to make it consistent with what the Unity 2021 LTS does in their own iOS build export code and I'm also (un)registering the views as framework listener, to properly handle the callbacks optionally passed in the view on the RN side.

Happy to help, let me know if I can adapt the code somehow.