### PR TITLE
fix(android): Don't crash when unmounting the view during transition

### DIFF
--- a/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnity.java
+++ b/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnity.java
@@ -107,6 +107,13 @@ public class ReactNativeUnity {
             return;
         }
         if (unityPlayer.getParent() != null) {
+            // NOTE: If we're being detached as part of the transition, make sure
+            // to explicitly finish the transition first, as it might still keep
+            // the view's parent around despite calling `removeView()` here. This
+            // prevents a crash on an `addContentView()` later on.
+            // Otherwise, if there's no transition, it's a no-op.
+            // See https://stackoverflow.com/a/58247331
+            ((ViewGroup) unityPlayer.getParent()).endViewTransition(unityPlayer);
             ((ViewGroup) unityPlayer.getParent()).removeView(unityPlayer);
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
I'm using `@react-navigation/native-stack` that uses `react-native-screens` internally: my screens by default use a portrait orientation but the screen that hosts the Unity view sometimes uses both orientations, depending on the game/content that I'm spinning up in Unity.

While unloading the player and bringing the app back to my portrait-locked screens, the following crash happens:
```
java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
	at android.view.ViewGroup.addViewInner(ViewGroup.java:6084)
	at android.view.ViewGroup.addView(ViewGroup.java:5903)
	at android.view.ViewGroup.addView(ViewGroup.java:5875)
	at androidx.appcompat.app.AppCompatDelegateImpl.addContentView(AppCompatDelegateImpl.java:716)
	at androidx.appcompat.app.AppCompatActivity.addContentView(AppCompatActivity.java:213)
	at com.azesmwayreactnativeunity.ReactNativeUnity.addUnityViewToBackground(ReactNativeUnity.java:117)
	at com.azesmwayreactnativeunity.ReactNativeUnityView.onDetachedFromWindow(ReactNativeUnityView.java:72)
	at android.view.View.dispatchDetachedFromWindow(View.java:22035)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:4776)
	at android.view.ViewGroup.clearDisappearingChildren(ViewGroup.java:8083)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:4770)
	at android.view.ViewGroup.clearDisappearingChildren(ViewGroup.java:8083)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:4770)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:4768)
	at android.view.ViewGroup.endViewTransition(ViewGroup.java:8194)
	at com.swmansion.rnscreens.ScreenStack.endViewTransition(ScreenStack.kt:53)
	at androidx.fragment.app.DefaultSpecialEffectsController$4$1.run(DefaultSpecialEffectsController.java:257)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:226)
	at android.os.Looper.loop(Looper.java:313)
	at android.app.ActivityThread.main(ActivityThread.java:8751)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
```

Looking at the answer at https://stackoverflow.com/a/58247331 that I found, it seems that the ongoing screen rotation keeps a hold of the parent view, despite calling `removeView()` directly, thus prompting the crash when we try to add a child view that already has a parent. This patch attempts to fix that and I can confirm that it fixed things for me locally.