### PR TITLE
Expose windowFocusChanged as a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ export default Unity;
 
 - `unloadUnity()` - the Unity is unloaded automatically when the react-native component is unmounted, but if you want to unload the Unity, you can call this method
 - `pauseUnity?: (pause: boolean)` - pause the Unity
+- `windowFocusChanged(hasFocus: boolean = false)` - simulate focus change (intended to be used to recover from black screen (not rendering) after remounting Unity view when `resumeUnity` does not work)  **ANDROID ONLY**
 
 # Contributing
 

--- a/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnityViewManager.java
+++ b/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnityViewManager.java
@@ -105,6 +105,9 @@ public class ReactNativeUnityViewManager extends SimpleViewManager<ReactNativeUn
             case "resumeUnity":
                 ReactNativeUnity.getPlayer().resume();
                 return;
+            case "windowFocusChanged":
+                ReactNativeUnity.getPlayer().windowFocusChanged(args.getBoolean(0));
+                return;
             default:
                 throw new IllegalArgumentException(String.format(
                         "Unsupported command %s received by %s.",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,6 +65,15 @@ export default class UnityView extends React.Component<ReactNativeUnityViewProps
     );
   }
 
+  public windowFocusChanged(hasFocus = true) {
+    if (Platform.OS !== 'android') return;
+    UIManager.dispatchViewManagerCommand(
+      findNodeHandle(this),
+      this.getCommand('windowFocusChanged'),
+      [Boolean(hasFocus)]
+    );
+  }
+
   private getCommand(cmd: string): any {
     if (Platform.OS === 'ios') {
       return UIManager.getViewManagerConfig('ReactNativeUnityView').Commands[


### PR DESCRIPTION
Some versions of Unity Player show black screen after remounted (see #59
for reference). The root cause is not clear but putting the app in
background and then bringing it back fixes the problem. To simulate this
process, `UnityPlayer.windowFocusChanged` is exposed as a command to be
invoked from within React Native when necessary.