### PR TITLE
Fix hard crash on Android

### DIFF
--- a/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnity.java
+++ b/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnity.java
@@ -37,49 +37,51 @@ public class ReactNativeUnity {
       callback.onReady();
       return;
     }
-    activity.runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-        activity.getWindow().setFormat(PixelFormat.RGBA_8888);
-        int flag = activity.getWindow().getAttributes().flags;
-        boolean fullScreen = false;
-        if ((flag & WindowManager.LayoutParams.FLAG_FULLSCREEN) == WindowManager.LayoutParams.FLAG_FULLSCREEN) {
-          fullScreen = true;
-        }
-
-        unityPlayer = new UnityPlayer(activity, new IUnityPlayerLifecycleEvents() {
-          @Override
-          public void onUnityPlayerUnloaded() {
-            callback.onUnload();
+    if (activity) {
+      activity.runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          activity.getWindow().setFormat(PixelFormat.RGBA_8888);
+          int flag = activity.getWindow().getAttributes().flags;
+          boolean fullScreen = false;
+          if ((flag & WindowManager.LayoutParams.FLAG_FULLSCREEN) == WindowManager.LayoutParams.FLAG_FULLSCREEN) {
+            fullScreen = true;
           }
 
-          @Override
-          public void onUnityPlayerQuitted() {
-            callback.onQuit();
+          unityPlayer = new UnityPlayer(activity, new IUnityPlayerLifecycleEvents() {
+            @Override
+            public void onUnityPlayerUnloaded() {
+              callback.onUnload();
+            }
+
+            @Override
+            public void onUnityPlayerQuitted() {
+              callback.onQuit();
+            }
+          });
+
+          try {
+            // wait a moment. fix unity cannot start when startup.
+            Thread.sleep(1000);
+          } catch (Exception e) {
           }
-        });
 
-        try {
-          // wait a moment. fix unity cannot start when startup.
-          Thread.sleep(1000);
-        } catch (Exception e) {
+          // start unity
+          addUnityViewToBackground();
+          unityPlayer.windowFocusChanged(true);
+          unityPlayer.requestFocus();
+          unityPlayer.resume();
+
+          // restore window layout
+          if (!fullScreen) {
+            activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+            activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+          }
+          _isUnityReady = true;
+          callback.onReady();
         }
-
-        // start unity
-        addUnityViewToBackground();
-        unityPlayer.windowFocusChanged(true);
-        unityPlayer.requestFocus();
-        unityPlayer.resume();
-
-        // restore window layout
-        if (!fullScreen) {
-          activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-          activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        }
-        _isUnityReady = true;
-        callback.onReady();
-      }
-    });
+      });
+    }
   }
 
   public static void pause() {

--- a/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnity.java
+++ b/android/src/main/java/com/azesmwayreactnativeunity/ReactNativeUnity.java
@@ -37,7 +37,7 @@ public class ReactNativeUnity {
       callback.onReady();
       return;
     }
-    if (activity) {
+    if (activity != null) {
       activity.runOnUiThread(new Runnable() {
         @Override
         public void run() {


### PR DESCRIPTION
ReactNativeUnity.java -> public static void createPlayer -> added existence check for activity

if (activity != null) {
activity.runOnUiThread(new Runnable() {
@OverRide
public void run() {
...
}

This fix resolved a hard crash on Android:
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.app.Activity.runOnUiThread(java.lang.Runnable)' on a null object reference
at com.azesmwayreactnativeunity.ReactNativeUnity.createPlayer(ReactNativeUnity.java:40)