### PR TITLE
UnityPlayer cannot be converted to FrameLayout

### DIFF
--- a/android/src/main/java/com/azesmwayreactnativeunity/UPlayer.java
+++ b/android/src/main/java/com/azesmwayreactnativeunity/UPlayer.java
@@ -97,7 +97,7 @@ public class UPlayer {
 
             return (FrameLayout) getFrameLayout.invoke(unityPlayer);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            return unityPlayer;
+            return (FrameLayout) this.requestFrame();
         }
     }
 


### PR DESCRIPTION
jusk yoinked `FrameLayout frame = (FrameLayout) this.requestFrame();` from `requestFocusPlayer()` and it succeeded