### PR TITLE
Add Unity post-processing build scripts for iOS and Android

### DIFF
--- a/unity/Edtior/PostProcessBuild/PostProcessingBuildAndroid.cs
+++ b/unity/Edtior/PostProcessBuild/PostProcessingBuildAndroid.cs
@@ -32,6 +32,6 @@ public class PostProcessingBuildAndroid
         }
 
         manifest.Save(manifestPath);
-        Debug.Log("Removed intent-filters from AndroidManifest.xml Success!.");
+        Debug.Log("[Post Build] Android : Removed intent-filters from AndroidManifest.xml Success!.");
     }
 }

--- a/unity/Edtior/PostProcessBuild/PostProcessingBuildAndroid.cs
+++ b/unity/Edtior/PostProcessBuild/PostProcessingBuildAndroid.cs
@@ -1,0 +1,37 @@
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEngine;
+using System.IO;
+using System.Xml;
+
+public class PostProcessingBuildAndroid
+{
+    [PostProcessBuild(1)]
+    public static void OnPostBuild(BuildTarget target, string pathToBuiltProject)
+    {
+        if (target != BuildTarget.Android) return;
+
+        var manifestPath = Path.Combine(pathToBuiltProject, "src", "main", "AndroidManifest.xml");
+        if (!File.Exists(manifestPath)) return;
+
+        XmlDocument manifest = new XmlDocument();
+        manifest.Load(manifestPath);
+
+        XmlNode appNode = manifest.SelectSingleNode("/manifest/application");
+
+        if (appNode != null)
+        {
+            foreach (XmlNode activityNode in appNode.SelectNodes(".//activity"))
+            {
+                var intentFilters = activityNode.SelectNodes("intent-filter");
+                for (int i = intentFilters.Count - 1; i >= 0; i--)
+                {
+                    activityNode.RemoveChild(intentFilters[i]);
+                }
+            }
+        }
+
+        manifest.Save(manifestPath);
+        Debug.Log("Removed intent-filters from AndroidManifest.xml Success!.");
+    }
+}

--- a/unity/Edtior/PostProcessBuild/PostProcessingBuildIOS.cs
+++ b/unity/Edtior/PostProcessBuild/PostProcessingBuildIOS.cs
@@ -1,0 +1,53 @@
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEditor.iOS.Xcode;
+using UnityEngine;
+
+public class PostBuildIOS
+{
+    [PostProcessBuild]
+    public static void OnPostBuild(BuildTarget target, string pathToBuiltProject)
+    {
+        if (target != BuildTarget.iOS) return;
+
+        string projPath = PBXProject.GetPBXProjectPath(pathToBuiltProject);
+        PBXProject proj = new PBXProject();
+        proj.ReadFromFile(projPath);
+
+#if UNITY_2019_3_OR_NEWER
+        string frameworkTarget = proj.GetUnityFrameworkTargetGuid();
+        string mainTarget = proj.GetUnityMainTargetGuid();
+#else
+        string frameworkTarget = proj.TargetGuidByName("UnityFramework");
+        string mainTarget = proj.TargetGuidByName("Unity-iPhone");
+#endif
+
+        // Change Data folder to UnityFramework
+        string dataFolderPath = "Data";
+        string dataFolderGuid = proj.FindFileGuidByProjectPath(dataFolderPath);
+        if (!string.IsNullOrEmpty(dataFolderGuid))
+        {
+            proj.RemoveFileFromBuild(mainTarget, dataFolderGuid);
+            proj.AddFileToBuild(frameworkTarget, dataFolderGuid);
+            Debug.Log("[Post Build] iOS : 'Data' folder reassigned to UnityFramework.");
+        }
+
+        // Change NativeCallProxy.h to Public
+        string headerPath = "Libraries/Plugins/iOS/NativeCallProxy.h";
+        string headerGuid = proj.FindFileGuidByProjectPath(headerPath);
+
+        if (!string.IsNullOrEmpty(headerGuid))
+        {
+            proj.RemoveFileFromBuild(mainTarget, headerGuid);
+            proj.AddPublicHeaderToBuild(frameworkTarget, headerGuid);
+
+            Debug.Log("[Post Build] iOS : NativeCallProxy.h set as Public in UnityFramework.");
+        }
+        else
+        {
+            Debug.LogWarning("[Post Build] iOS : NativeCallProxy.h not found. Check Unity export path.");
+        }
+
+        proj.WriteToFile(projPath);
+    }
+}


### PR DESCRIPTION
### Summary

This PR adds Unity post-processing build scripts for both **iOS** and **Android** platforms to automate the setup required for proper integration with the `@azesmway/react-native-unity` package.

#### ✅ iOS:
- Reassigns the `Data/` folder from the default `Unity-iPhone` target to the `UnityFramework` target
- Marks `NativeCallProxy.h` as a **Public** header in `UnityFramework` for external access via React Native

#### ✅ Android:
- Removes all `<intent-filter>` blocks from `AndroidManifest.xml` in the Unity-generated `unityLibrary` to prevent duplicate launcher activity conflicts with the React Native host app

### Notes
The scripts are placed in: `unity/Editor/PostProcessBuild/` They run automatically when Unity builds for Android or iOS.